### PR TITLE
Add hrefs to social media footer links

### DIFF
--- a/index.html
+++ b/index.html
@@ -1195,6 +1195,7 @@
             <a href="https://maps.google.com" class="label-2 footer-link hover-underline">Google Map</a>
           </li>
           
+          
 
         </ul>
 

--- a/index.html
+++ b/index.html
@@ -1156,7 +1156,7 @@
 
         <ul class="footer-list">
 
-          <li>
+          <!-- <li>
             <a href="#" class="label-2 footer-link hover-underline">Facebook</a>
           </li>
 
@@ -1174,7 +1174,27 @@
 
           <li>
             <a href="#" class="label-2 footer-link hover-underline">Google Map</a>
+          </li> -->
+          <li>
+            <a href="https://www.facebook.com" class="label-2 footer-link hover-underline">Facebook</a>
           </li>
+          
+          <li>
+            <a href="https://www.instagram.com" class="label-2 footer-link hover-underline">Instagram</a>
+          </li>
+          
+          <li>
+            <a href="https://www.twitter.com" class="label-2 footer-link hover-underline">Twitter</a>
+          </li>
+          
+          <li>
+            <a href="https://www.youtube.com" class="label-2 footer-link hover-underline">Youtube</a>
+          </li>
+          
+          <li>
+            <a href="https://maps.google.com" class="label-2 footer-link hover-underline">Google Map</a>
+          </li>
+          
 
         </ul>
 


### PR DESCRIPTION
Description:
This PR updates the social media links in the footer by replacing the placeholder href="#" with actual URLs for the following platforms:

Facebook
Instagram
Twitter
YouTube
Google Maps
Changes made:
Updated Facebook link to https://www.facebook.com
Updated Instagram link to https://www.instagram.com
Updated Twitter link to https://www.twitter.com
Updated YouTube link to https://www.youtube.com
Updated Google Maps link to https://maps.google.com
Impact:
This change ensures that the footer links are now functional and direct users to the respective social media platforms.