### PR TITLE
 Add PWA support with manifest and service worker

### DIFF
--- a/sw.js
+++ b/sw.js
@@ -1,0 +1,23 @@
+const CACHE_NAME = 'grilli-v1';
+const urlsToCache = [
+  '/grilli/',
+  '/grilli/index.html',
+  '/grilli/assets/css/style.css',
+  '/grilli/assets/js/app.js',
+  '/grilli/assets/images/logo.png',
+  '/grilli/assets/favicon-192x192.png'
+];
+
+self.addEventListener('install', event => {
+  event.waitUntil(
+    caches.open(CACHE_NAME)
+      .then(cache => cache.addAll(urlsToCache))
+  );
+});
+
+self.addEventListener('fetch', event => {
+  event.respondWith(
+    caches.match(event.request)
+      .then(response => response || fetch(event.request))
+  );
+});


### PR DESCRIPTION
Added:
- manifest.json for PWA (app name, icons, theme color)
- sw.js for offline caching
- Updated index.html with meta tags and service worker registration

Now users can add Grilli to home screen on Android/iOS devices.

Tested on Chrome mobile.